### PR TITLE
fix: Update project name to TradeFiAI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Project Title (DeFiAI - AI Powered Trading Platform)
+# TradeFiAI - AI Powered Trading Platform
 
 ## Introduction/Overview
 
-DeFiAI is a cutting-edge decentralized finance (DeFi) application designed to empower users with AI-driven insights and automated trading capabilities for the cryptocurrency markets. The platform integrates intelligent algorithms to analyze market conditions, manage portfolios, and execute trades with precision, aiming to maximize returns while managing risks. It offers a user-friendly interface for both seasoned traders and newcomers to navigate the complexities of DeFi.
+TradeFiAI is a cutting-edge decentralized finance (DeFi) application designed to empower users with AI-driven insights and automated trading capabilities for the cryptocurrency markets. The platform integrates intelligent algorithms to analyze market conditions, manage portfolios, and execute trades with precision, aiming to maximize returns while managing risks. It offers a user-friendly interface for both seasoned traders and newcomers to navigate the complexities of DeFi.
 
 
 ## Features


### PR DESCRIPTION
Updated all relevant instances of the project name from "DeFiAI" to "TradeFiAI" in the README.md file. This includes:
- The main project title.
- Mentions in the "Introduction/Overview" section.

The term "DeFi" as an acronym for "decentralized finance" has been intentionally retained where appropriate.